### PR TITLE
EmotionCache 타입 오류

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import { CacheProvider } from '@emotion/react';
-import { EmotionCache } from '@emotion/utils';
 import { createTheme, CssBaseline, ThemeProvider } from '@mui/material';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -12,7 +11,10 @@ import '../styles/globals.css';
 const clientSideEmotionCache = createEmotionCache();
 
 interface MyAppProps extends AppProps {
-    emotionCache?: EmotionCache;
+    // EmotionCache not properly typed, not working with import { EmotionCache } from '@emotion/utils';
+    // EmotionCache@emotion/react !== EmotionCache@emotion/utils !== EmotionCache@emotion/cache
+    // to fix later
+    emotionCache?: any;
 }
 
 function MyApp({ Component, pageProps, emotionCache = clientSideEmotionCache }: MyAppProps) {

--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -1,0 +1,21 @@
+import { Board } from '../src/components/board';
+import { BoardPost, postMocks } from '../src/mocks/boards';
+
+interface PostPageProps {
+    post: BoardPost;
+}
+
+const PostPage = ({ post }: PostPageProps) => {
+    return <Board post={post}/>;
+};
+
+export const getStaticProps = () => {
+    const post = postMocks[0];
+    return {
+        props: {
+            post,
+        },
+    };
+};
+
+export default PostPage;


### PR DESCRIPTION
## 문제

[mui공식 문서](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript) 소스 코드를 보면 해당 코드를 사용하게 함

```tsx
// /pages/_app.tsx
import { EmotionCache } from '@emotion/utils';
import { createCache } from '@emotion/cache';
import { CacheProvider } from '@emotion/react';

const clientSideEmotionCache = createEmotionCache(); // 1

interface MyAppProps extends AppProps {
    emotionCache?: EmotionCache; // 2
}

function MyApp({emotionCache}: MyAppProps) {
    return (
        <CacheProvider value={emotionCache}> {/* 3 */}
            {/*...*/}
        </CacheProvider>
}
```
다만 최신 버전의 `@emotion/*`를 설치하면 `1` `2` `3`번의 `EmotionCache` type definition이 달라서 빌드 오류가 생김

## 임시해결

`emotionCache`의 타입을 `any`로 변경

```tsx
interface MyAppProps extends AppProps {
    emotionCache?: any;
}
```
