### PR TITLE
회원가입 폼 UI

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,6 +1,7 @@
 import { AlternateEmailOutlined, LockOutlined, LoginOutlined } from '@mui/icons-material';
 import { Button, InputAdornment, Stack, TextField } from '@mui/material';
 import { useForm } from 'react-hook-form';
+import { validationRegex } from '../../tools/validation';
 
 interface LoginFormProps {
 
@@ -15,9 +16,6 @@ const defaultValues: LoginProps = {
     email: '',
     password: '',
 };
-
-// source: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-const emailValidationRegex = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 const LoginForm = ({}: LoginFormProps) => {
     const { register, handleSubmit, formState } = useForm<LoginProps>({
@@ -36,7 +34,7 @@ const LoginForm = ({}: LoginFormProps) => {
                     sx: { borderRadius: 0 },
                     startAdornment: (
                         <InputAdornment position={'start'}>
-                            <AlternateEmailOutlined fontSize={'small'}/>
+                            <AlternateEmailOutlined fontSize={'small'} />
                         </InputAdornment>),
                 }}
                            label={'이메일'}
@@ -44,13 +42,13 @@ const LoginForm = ({}: LoginFormProps) => {
                            helperText={formState.errors['email']?.message}
                            {...register('email', {
                                required: '이메일을 입력해주세요',
-                               pattern: { value: emailValidationRegex, message: '올바른 이메일 주소를 입력해주세요' },
+                               pattern: validationRegex.email,
                            })} />
                 <TextField InputProps={{
                     sx: { borderRadius: 0 },
                     startAdornment: (
                         <InputAdornment position={'start'}>
-                            <LockOutlined fontSize={'small'}/>
+                            <LockOutlined fontSize={'small'} />
                         </InputAdornment>
                     ),
                 }}
@@ -59,9 +57,14 @@ const LoginForm = ({}: LoginFormProps) => {
                            error={!!formState.errors['password']}
                            helperText={formState.errors['password']?.message}
                            {...register('password', { required: '비밀번호를 입력해주세요' })} />
-                <Button size={'large'} variant={'contained'} sx={{ borderRadius: 0 }} disableElevation
-                        startIcon={<LoginOutlined fontSize={'small'}/>}
-                        type={'submit'}>로그인</Button>
+                <Button size={'large'}
+                        variant={'contained'}
+                        sx={{ borderRadius: 0 }}
+                        disableElevation
+                        startIcon={<LoginOutlined fontSize={'small'} />}
+                        type={'submit'}>
+                    로그인
+                </Button>
             </Stack>
         </form>
     );

--- a/src/components/sign-up/SignUpForm.tsx
+++ b/src/components/sign-up/SignUpForm.tsx
@@ -1,0 +1,133 @@
+import { AlternateEmailOutlined, BadgeOutlined, GroupAddOutlined, LockOutlined } from '@mui/icons-material';
+import { Box, Button, InputAdornment, TextField } from '@mui/material';
+import { RegisterOptions, useForm, UseFormWatch } from 'react-hook-form';
+import { validationRegex } from '../../tools/validation';
+import { defaultSignUpDto, SignUpDto } from '../../types/SignUpDto';
+
+interface SignUpFormProps {
+}
+
+const registerOptions:
+    Record<keyof Omit<SignUpDto, 'passwordConfirm'>, RegisterOptions>
+    & Record<keyof Pick<SignUpDto, 'passwordConfirm'>, (watch: UseFormWatch<SignUpDto>) => RegisterOptions>
+    = {
+    nickName: {
+        required: '닉네임을 입력해주세요',
+    },
+    introduction: {},
+    profileImage: {},
+    name: {
+        required: '이름을 입력해주세요',
+        pattern: validationRegex.name,
+    },
+    email: {
+        required: '이메일을 입력해주세요',
+        pattern: validationRegex.email,
+    },
+    password: {
+        required: '비밀번호를 입력해주세요',
+        pattern: validationRegex.password,
+    },
+    passwordConfirm: (watch: UseFormWatch<SignUpDto>): RegisterOptions => ({
+        required: '비밀번호를 한번 더 입력해주세요',
+        validate: value => value === watch('password') || '비밀번호가 일치 하지 않습니다',
+    }),
+};
+
+const EmailIcon = (
+    <InputAdornment position={'start'}>
+        <AlternateEmailOutlined fontSize={'small'} />
+    </InputAdornment>
+);
+
+const PasswordIcon = (
+    <InputAdornment position={'start'}>
+        <LockOutlined fontSize={'small'} />
+    </InputAdornment>
+);
+
+const UserIcon = (
+    <InputAdornment position={'start'}>
+        <BadgeOutlined fontSize={'small'} />
+    </InputAdornment>
+);
+
+const SignUpForm = ({}: SignUpFormProps) => {
+    const { register, handleSubmit, formState, watch } = useForm<SignUpDto>({
+        defaultValues: defaultSignUpDto,
+    });
+
+    const onSubmit = handleSubmit((data) => {
+        // TODO: send request to back
+        alert(JSON.stringify(data));
+    });
+
+    return (
+        <form onSubmit={onSubmit}>
+            <Box display={'flex'} flexDirection={'column'}>
+
+                <TextField InputProps={{ sx: { borderRadius: 0 }, startAdornment: EmailIcon }}
+                           sx={{ marginBottom: 1 }}
+                           label={'이메일'}
+                           required
+                           error={!!formState.errors['email']}
+                           helperText={formState.errors['email']?.message}
+                           {...register('email', registerOptions.email)} />
+
+                <TextField InputProps={{ sx: { borderRadius: 0 }, startAdornment: PasswordIcon }}
+                           sx={{ marginTop: 1, marginBottom: 1 }}
+                           label={'비밀번호'}
+                           type={'password'}
+                           required
+                           error={!!formState.errors['password']}
+                           helperText={formState.errors['password']?.message}
+                           {...register('password', registerOptions.password)} />
+
+                <TextField InputProps={{ sx: { borderRadius: 0 }, startAdornment: PasswordIcon }}
+                           sx={{ marginTop: 1, marginBottom: 1 }}
+                           label={'비밀번호 재확인'}
+                           type={'password'}
+                           required
+                           error={!!formState.errors['passwordConfirm']}
+                           helperText={formState.errors['passwordConfirm']?.message}
+                           {...register('passwordConfirm', registerOptions.passwordConfirm(watch))} />
+
+                <TextField InputProps={{ sx: { borderRadius: 0 }, startAdornment: UserIcon }}
+                           sx={{ marginTop: 5, marginBottom: 1 }}
+                           label={'이름'}
+                           required
+                           error={!!formState.errors['name']}
+                           helperText={formState.errors['name']?.message}
+                           {...register('name', registerOptions.name)} />
+
+                <TextField InputProps={{ sx: { borderRadius: 0 }, startAdornment: UserIcon }}
+                           sx={{ marginTop: 1, marginBottom: 1 }}
+                           label={'닉네임'}
+                           required
+                           error={!!formState.errors['nickName']}
+                           helperText={formState.errors['nickName']?.message}
+                           {...register('nickName', registerOptions.nickName)} />
+
+                <TextField InputProps={{ sx: { borderRadius: 0 } }}
+                           sx={{ marginTop: 1, marginBottom: 1 }}
+                           label={'소개글'}
+                           multiline
+                           rows={4}
+                           error={!!formState.errors['introduction']}
+                           helperText={formState.errors['introduction']?.message}
+                           {...register('introduction', registerOptions.introduction)} />
+
+                <Button size={'large'}
+                        variant={'contained'}
+                        sx={{ borderRadius: 0, marginTop: 1 }}
+                        disableElevation
+                        startIcon={<GroupAddOutlined fontSize={'small'} />}
+                        type={'submit'}>
+                    회원가입
+                </Button>
+            </Box>
+        </form>
+    );
+};
+
+export default SignUpForm;

--- a/src/stories/sign-up/SignUpForm.stories.tsx
+++ b/src/stories/sign-up/SignUpForm.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import SignUpForm from '../../components/sign-up/SignUpForm';
+
+export default {
+    title: 'components/SignUp/SignUpForm',
+    component: SignUpForm,
+} as ComponentMeta<typeof SignUpForm>;
+
+const Template: ComponentStory<typeof SignUpForm> = (args) => <SignUpForm {...args} />;
+
+export const Form = Template.bind({});

--- a/src/tools/validation.ts
+++ b/src/tools/validation.ts
@@ -1,0 +1,18 @@
+import { ValidationRule } from 'react-hook-form';
+
+type ValidationField = 'email' | 'name' | 'password'
+export const validationRegex: Record<ValidationField, ValidationRule<RegExp>> = {
+    email: {
+        // source: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+        value: /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+        message: '올바른 이메일 주소를 입력해주세요',
+    },
+    name: {
+        value: /^[가-힣]{2,4}$/,
+        message: '이름은 2 ~ 4자의 한글이여야 합니다',
+    },
+    password: {
+        value: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,10}$/,
+        message: '비밀번호는 하나 이상의 대문자, 소문자, 숫자 및 특수 문자로 이루어진 6 ~ 10자이여야 합니다',
+    },
+};

--- a/src/types/SignUpDto.ts
+++ b/src/types/SignUpDto.ts
@@ -1,0 +1,19 @@
+export interface SignUpDto {
+    email: string;
+    nickName: string;
+    name: string;
+    password: string;
+    passwordConfirm: string;
+    introduction: string;
+    profileImage: string;
+}
+
+export const defaultSignUpDto: Readonly<SignUpDto> = {
+    email: '',
+    name: '',
+    nickName: '',
+    password: '',
+    passwordConfirm: '',
+    introduction: '',
+    profileImage: '',
+};


### PR DESCRIPTION
- [x] 회원가입을 위한 폼 추가
- [x] `SignUpDto` 생성
- [x] `emailValidationRegex`을 `src/tools/validation.ts`로 추출
- [x] 이메일, 비밀번호, 이름, 닉네임 validation

##  예시

![Kapture 2022-04-28 at 00 19 33](https://user-images.githubusercontent.com/16722555/165640795-b9448254-8329-4a7e-b02c-f5da22589d79.gif)
